### PR TITLE
fix: conditionally create the role for project-level snapshot creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -272,7 +272,7 @@ resource "google_project_iam_member" "agentless_orchestrate_service_account_user
 
 // Role for Snapshot Creation
 resource "google_project_iam_custom_role" "agentless_orchestrate_project" {
-  for_each = setunion([local.scanning_project_id], local.included_projects)
+  for_each = var.global && (var.integration_type == "PROJECT") ? setunion([local.scanning_project_id], local.included_projects) : []
 
   project = each.key
   role_id = replace("${var.prefix}-snapshot-${local.suffix}", "-", "_")


### PR DESCRIPTION
## Summary

This PR makes creation of the Snapshot Creation role conditional upon the module being run with `global = True` 

## How did you test this change?

Used `make ci` and @ammarekbote is testing in his lab as well.

## Issue
N/A