### PR TITLE
fix: derive bucket name for regional deployments

### DIFF
--- a/examples/project-level-multi-region/main.tf
+++ b/examples/project-level-multi-region/main.tf
@@ -10,6 +10,13 @@ provider "google" {
   region = "us-central1"
 }
 
+locals {
+  project_filter_list = [
+    "monitored-project-1",
+    "monitored-project-2"
+  ]
+}
+
 module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
   source = "../.."
 
@@ -17,10 +24,7 @@ module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
     google = google.use1
   }
 
-  project_filter_list = [
-    "monitored-project-1",
-    "monitored-project-2"
-  ]
+  project_filter_list = local.project_filter_list
 
   global                    = true
   regional                  = true
@@ -33,6 +37,8 @@ module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
   providers = {
     google = google.usc1
   }
+
+  project_filter_list = local.project_filter_list
 
   regional                = true
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ locals {
   included_projects = var.global ? toset([for project in var.project_filter_list : project if !(substr(project, 0, 1) == "-")]) : []
   excluded_projects = var.global ? toset([for project in var.project_filter_list : project if substr(project, 0, 1) == "-"]) : []
 
-  bucket_name = var.global ? google_storage_bucket.lacework_bucket[0].name : ""
+  bucket_name = "${var.prefix}-bucket-${local.suffix}"
   bucket_roles = var.global ? ({
     "roles/storage.admin" = [
       "projectEditor:${local.scanning_project_id}",
@@ -130,7 +130,7 @@ resource "google_storage_bucket" "lacework_bucket" {
   count = var.global ? 1 : 0
 
   project       = local.scanning_project_id
-  name          = "${var.prefix}-bucket-${local.suffix}"
+  name          = local.bucket_name
   force_destroy = var.bucket_force_destroy
   location      = local.region
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Bucket missing for multi region deployment

## How did you test this change?

Deployed the jobs with new changes and verified bucket is populated for all region jobs.

## Issue

Bucket is not populated for cloud run jobs in multi region deployment
