### PR TITLE
fix: removed prefix from `GCP_ORG_ID` env var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -421,7 +421,7 @@ resource "google_cloud_run_v2_job" "agentless_orchestrate" {
         }
         env {
           name  = "GCP_ORG_ID"
-          value = "organizations/${local.organization_id}"
+          value = local.organization_id
         }
         env {
           name  = "GCP_SCAN_SCOPE"


### PR DESCRIPTION
## Summary

Simplifying the `GCP_ORG_ID` value to eliminate the prefix.  The value will be and empty string if the scanning project is not in an organization.

## How did you test this change?

Tested in an project-level multi-region deployment which is not in an org.

## Issue

N/A