### PR TITLE
Allow scanner to terminate host compute instance

### DIFF
--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -94,6 +94,7 @@ resource "google_project_iam_custom_role" "agentless_scan" {
     "compute.disks.create",
     "compute.disks.get",
     "compute.instances.create",
+    "compute.instances.delete",
     "compute.snapshots.delete",
     "compute.snapshots.list",
     "compute.snapshots.setLabels",


### PR DESCRIPTION


## Summary

Add permissions to scanner role associated with service account used to launch compute instances.
This allows the scanner container to issue (self) deletion request once the scanning is done and reduce the cleanup time.

## How did you test this change?
Verified no error messages seen while (self) deleting the compute instance
