### PR TITLE
Add multi volume variable

### DIFF
--- a/examples/org-level-single-region/main.tf
+++ b/examples/org-level-single-region/main.tf
@@ -1,6 +1,8 @@
 provider "lacework" {}
 
-provider "google" {}
+provider "google" {
+  region = "us-central1"
+}
 
 module "lacework_gcp_agentless_scanning_org_single_region" {
   source = "../.."

--- a/examples/project-level-single-region/main.tf
+++ b/examples/project-level-single-region/main.tf
@@ -1,6 +1,8 @@
 provider "lacework" {}
 
-provider "google" {}
+provider "google" {
+  region = "us-central1"
+}
 
 module "lacework_gcp_agentless_scanning_project_single_region" {
   source = "../.."

--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ resource "lacework_integration_gcp_agentless_scanning" "lacework_cloud_account" 
   scanning_project_id = local.scanning_project_id
   filter_list         = var.project_filter_list
   scan_multi_volume   = var.scan_multi_volume
+  scan_stopped_instances = var.scan_stopped_instances
   credentials {
     client_id      = local.lacework_integration_service_account_json_key.client_id
     private_key_id = local.lacework_integration_service_account_json_key.private_key_id

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,7 @@ resource "lacework_integration_gcp_agentless_scanning" "lacework_cloud_account" 
   bucket_name         = google_storage_bucket.lacework_bucket[0].name
   scanning_project_id = local.scanning_project_id
   filter_list         = var.project_filter_list
+  scan_multi_volume   = var.scan_multi_volume
   credentials {
     client_id      = local.lacework_integration_service_account_json_key.client_id
     private_key_id = local.lacework_integration_service_account_json_key.private_key_id

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,12 @@ variable "scan_host_vulnerabilities" {
   default     = true
 }
 
+variable "scan_multi_volume" {
+  type = bool
+  description = "Whether to scan secondary volumes. Defaults to `false`."
+  default = false
+}
+
 variable "scan_frequency_hours" {
   type        = number
   description = "How often in hours the scan will run in hours. Defaults to `24`."

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,12 @@ variable "scan_multi_volume" {
   default = false
 }
 
+variable "scan_stopped_instances" {
+  type = bool
+  description = "Whether to scan stopped instances. Defaults to `false`."
+  default = false
+}
+
 variable "scan_frequency_hours" {
   type        = number
   description = "How often in hours the scan will run in hours. Defaults to `24`."


### PR DESCRIPTION
# Summary
This is part of the work of multi-volume (secondary volume) and stopped instances scanning features for agentless workload scanning. We are finishing up the feature by adding a toggle / boolean for integrations to indicate if they want to turn on Multi-Volume scanning and/or Stopped Instances scanning. This is handled on the backend (in sidekick) to "turn on" the feature if the boolean is set to true.

Last part of: https://github.com/lacework/go-sdk/pull/1275, https://github.com/lacework/terraform-provider-lacework/pull/484

# How did you test this change?

Tested by running terraform locally to confirm the variables came through properly:
![Screenshot 2023-07-15 at 9 14 37 AM](https://github.com/lacework/terraform-gcp-agentless-scanning/assets/107059599/0885cdf4-0f2e-493c-9b65-721af33b58ba)


# Issue
https://lacework.atlassian.net/browse/RAIN-54831