### PR TITLE
feat(RAIN-54831): Add multi volume & scan stopped instances variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,8 @@ resource "lacework_integration_gcp_agentless_scanning" "lacework_cloud_account" 
   bucket_name         = google_storage_bucket.lacework_bucket[0].name
   scanning_project_id = local.scanning_project_id
   filter_list         = var.project_filter_list
+  scan_multi_volume   = var.scan_multi_volume
+  scan_stopped_instances = var.scan_stopped_instances
   credentials {
     client_id      = local.lacework_integration_service_account_json_key.client_id
     private_key_id = local.lacework_integration_service_account_json_key.private_key_id

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,18 @@ variable "scan_host_vulnerabilities" {
   default     = true
 }
 
+variable "scan_multi_volume" {
+  type = bool
+  description = "Whether to scan secondary volumes. Defaults to `false`."
+  default = false
+}
+
+variable "scan_stopped_instances" {
+  type = bool
+  description = "Whether to scan stopped instances. Defaults to `false`."
+  default = true
+}
+
 variable "scan_frequency_hours" {
   type        = number
   description = "How often in hours the scan will run in hours. Defaults to `24`."


### PR DESCRIPTION
Summary
This is part of the work of multi-volume (secondary volume) and stopped instances scanning features for agentless workload scanning. We are finishing up the feature by adding a toggle / boolean for integrations to indicate if they want to turn on Multi-Volume scanning and/or Stopped Instances scanning. This is handled on the backend (in sidekick) to "turn on" the feature if the boolean is set to true.

Last part of: https://github.com/lacework/go-sdk/pull/1275, https://github.com/lacework/terraform-provider-lacework/pull/484

How did you test this change?
Tested by running terraform locally to confirm the variables came through properly:
![Screenshot 2023-07-12 at 11 15 58 AM](https://github.com/lacework/terraform-gcp-agentless-scanning/assets/107059599/4032b168-0793-4fe6-8620-7d9c23496415)


Issue
https://lacework.atlassian.net/browse/RAIN-54831