### PR TITLE
add permision to derive machine info from monitored projects

### DIFF
--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -13,6 +13,7 @@ resource "google_project_iam_custom_role" "agentless_orchestrate_monitored_proje
     "compute.disks.useReadOnly",
     "compute.instances.get",
     "compute.instances.list",
+    "compute.machineTypes.get",
     "compute.zones.list",
   ]
 }
@@ -34,6 +35,7 @@ resource "google_organization_iam_custom_role" "agentless_orchestrate" {
     "compute.disks.useReadOnly",
     "compute.instances.get",
     "compute.instances.list",
+    "compute.machineTypes.get",
     "compute.projects.get",
     "compute.zones.list",
     "resourcemanager.folders.list",

--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -66,6 +66,7 @@ resource "google_project_iam_custom_role" "agentless_orchestrate" {
     "compute.instances.list",
     "compute.instances.setMetadata",
     "compute.instances.setServiceAccount",
+    "compute.machineTypes.get",
     "compute.snapshots.create",
     "compute.snapshots.delete",
     "compute.snapshots.list",


### PR DESCRIPTION

## Summary
`compute.machineTypes.get` is needed to fetch metadata for compute instances
 
## How did you test this change?
Deployed with the the new changes to verify there are no regressions.

## Issue
https://lacework.atlassian.net/browse/LINK-1916