### PR TITLE
The default for scanning stopped instances should be 'false' as documented

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable "scan_multi_volume" {
 variable "scan_stopped_instances" {
   type = bool
   description = "Whether to scan stopped instances. Defaults to `false`."
-  default = true
+  default = false
 }
 
 variable "scan_frequency_hours" {


### PR DESCRIPTION
## Summary

[The documentation](https://docs.lacework.net/onboarding/faqs-agentless-workload-scanning#are-stopped-instances-scanned) states this should default to false.

## How did you test this change?

This is a trivial change of a default, so have performed no additional testing.

## Issue

N/A