### PR TITLE
allow scanner compute instance to access secret value

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | [google_project_iam_member.lacework_svc_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.required_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_secret_manager_secret.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
-| [google_secret_manager_secret_iam_member.member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.member_orchestrate_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.member_scan_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_service_account.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.agentless_scan](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |

--- a/main.tf
+++ b/main.tf
@@ -127,14 +127,24 @@ resource "google_secret_manager_secret_version" "agentless_orchestrate" {
 EOF
 }
 
-resource "google_secret_manager_secret_iam_member" "member" {
+resource "google_secret_manager_secret_iam_member" "member_orchestrate_service_account" {
   count = var.global ? 1 : 0
 
   project   = local.scanning_project_id
   secret_id = google_secret_manager_secret.agentless_orchestrate[0].secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
-  depends_on = [google_service_account.agentless_orchestrate]
+  depends_on = [ google_service_account.agentless_orchestrate ]
+}
+
+resource "google_secret_manager_secret_iam_member" "member_scan_service_account" {
+  count = var.global ? 1 : 0
+
+  project   = local.scanning_project_id
+  secret_id = google_secret_manager_secret.agentless_orchestrate[0].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${local.agentless_scan_service_account_email}"
+  depends_on = [ google_service_account.agentless_scan ]
 }
 
 // Storage Bucket for Analysis Data


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary
Scanner compute instances are launched with scan service account.
Recent changes on the scanner are sending an api request to lacework platform as part of first run. 
To make the api request, the scanner service account needs to access the secret value. 
This PR adds `agentless_scan_service_account_email` as one of the service principals that accesses the secret value.

## How did you test this change?
Ran the terraform and verified the scanner service account has the permissions to access the secret value now. 

![image](https://github.com/lacework/terraform-gcp-agentless-scanning/assets/1553680/e79fc9f6-3b11-4c43-98f9-3b7a1565b569)


## Issue
https://lacework.atlassian.net/browse/AWLS-121