### PR TITLE
feat: pass environment variables to cloud run task from terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.46 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.18 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.84.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 1.18.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 
 ## Modules
 
@@ -66,6 +66,7 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_environment_variables"></a> [additional\_environment\_variables](#input\_additional\_environment\_variables) | Optional list of additional environment variables passed to the Cloud Run task. | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_agentless_orchestrate_service_account_email"></a> [agentless\_orchestrate\_service\_account\_email](#input\_agentless\_orchestrate\_service\_account\_email) | The email of the service account for which to use during scan tasks. | `string` | `""` | no |
 | <a name="input_agentless_scan_secret_id"></a> [agentless\_scan\_secret\_id](#input\_agentless\_scan\_secret\_id) | The ID of the Google Secret containing the Lacework Account and Auth Token | `string` | `""` | no |
 | <a name="input_agentless_scan_service_account_email"></a> [agentless\_scan\_service\_account\_email](#input\_agentless\_scan\_service\_account\_email) | The email of the service account for which to use during scan tasks. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.46 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.18 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.84.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 1.18.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.84.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 1.18.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.46 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.18 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 

--- a/examples/custom-vpc-network/main.tf
+++ b/examples/custom-vpc-network/main.tf
@@ -73,8 +73,8 @@ module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
   regional = true
 
   custom_vpc_subnet = google_compute_subnetwork.awls_subnet_1.id
-  # example: how to disable public IP address on scanning VMs in GCP
-  additional_environment_variables = [{name="USE_PUBLIC_IPS", value="false"}]
+  # example: passing an environment variable to the cloud run task
+  additional_environment_variables = [{name="EXAMPLE_ENV_VAR", value="something"}]
 }
 
 module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {

--- a/examples/custom-vpc-network/main.tf
+++ b/examples/custom-vpc-network/main.tf
@@ -73,6 +73,8 @@ module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
   regional = true
 
   custom_vpc_subnet = google_compute_subnetwork.awls_subnet_1.id
+  # example: how to disable public IP address on scanning VMs in GCP
+  additional_environment_variables = [{name="USE_PUBLIC_IPS", value="false"}]
 }
 
 module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
@@ -86,4 +88,7 @@ module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1
 
   custom_vpc_subnet = google_compute_subnetwork.awls_subnet_2.id
+
+  # example: how to disable public IP address on scanning VMs in GCP
+  additional_environment_variables = [{name="USE_PUBLIC_IPS", value="false"}]
 }

--- a/examples/custom-vpc-network/main.tf
+++ b/examples/custom-vpc-network/main.tf
@@ -89,6 +89,6 @@ module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
 
   custom_vpc_subnet = google_compute_subnetwork.awls_subnet_2.id
 
-  # example: how to disable public IP address on scanning VMs in GCP
-  additional_environment_variables = [{name="USE_PUBLIC_IPS", value="false"}]
+  # example: how to pass an environment variable to a cloud task
+  additional_environment_variables = [{name="EXAMPLE_ENV_VAR", value="something"}]
 }

--- a/main.tf
+++ b/main.tf
@@ -358,7 +358,15 @@ resource "google_cloud_run_v2_job" "agentless_orchestrate" {
           value = var.custom_vpc_subnet
         }
 
+        dynamic "env" {
+          for_each = var.additional_environment_variables
+          content {
+            name = env.value["name"]
+            value = env.value["value"]
+          }
+        }
       }
+
       service_account = local.agentless_orchestrate_service_account_email
       timeout         = "3600s"
     }

--- a/variables.tf
+++ b/variables.tf
@@ -215,3 +215,13 @@ variable "global_module_reference" {
   }
   description = "A reference to the global lacework_gcp_agentless_scanning module for this account."
 }
+
+variable "additional_environment_variables" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default     = []
+  description = "Optional list of additional environment variables passed to the Cloud Run task."
+}
+


### PR DESCRIPTION
## Summary

Add a feature supported in the agentless-aws terraform provider but not GCP: ability to pass environment variables to the cloud run task.

## How did you test this change?

- [X] CI passes and shows added variable in custom-vpc example:
![image](https://github.com/lacework/terraform-gcp-agentless-scanning/assets/5673088/7eef4dbe-81fd-47a7-867d-e41fb23b4474)

## Issue

N/A, reported internally.