### PR TITLE
misc: add validator for organization id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
 
-  final_project_filter_list = length(var.global_module_reference.project_filter_list)>0 ? var.global_module_reference.project_filter_list : var.project_filter_list
+  final_project_filter_list = length(var.global_module_reference.project_filter_list) > 0 ? var.global_module_reference.project_filter_list : var.project_filter_list
 
   scanning_project_id = length(var.scanning_project_id) > 0 ? var.scanning_project_id : data.google_project.selected[0].project_id
   organization_id     = length(var.organization_id) > 0 ? var.organization_id : (data.google_project.selected[0].org_id != null ? data.google_project.selected[0].org_id : "")
@@ -78,13 +78,13 @@ resource "google_project_service" "required_apis" {
 resource "lacework_integration_gcp_agentless_scanning" "lacework_cloud_account" {
   count = var.global ? 1 : 0
 
-  name                = var.lacework_integration_name
-  resource_level      = var.integration_type
-  resource_id         = length(local.organization_id) > 0 ? local.organization_id : local.scanning_project_id
-  bucket_name         = google_storage_bucket.lacework_bucket[0].name
-  scanning_project_id = local.scanning_project_id
-  filter_list         = local.final_project_filter_list
-  scan_multi_volume   = var.scan_multi_volume
+  name                   = var.lacework_integration_name
+  resource_level         = var.integration_type
+  resource_id            = length(local.organization_id) > 0 ? local.organization_id : local.scanning_project_id
+  bucket_name            = google_storage_bucket.lacework_bucket[0].name
+  scanning_project_id    = local.scanning_project_id
+  filter_list            = local.final_project_filter_list
+  scan_multi_volume      = var.scan_multi_volume
   scan_stopped_instances = var.scan_stopped_instances
   credentials {
     client_id      = local.lacework_integration_service_account_json_key.client_id
@@ -130,21 +130,21 @@ EOF
 resource "google_secret_manager_secret_iam_member" "member_orchestrate_service_account" {
   count = var.global ? 1 : 0
 
-  project   = local.scanning_project_id
-  secret_id = google_secret_manager_secret.agentless_orchestrate[0].secret_id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
-  depends_on = [ google_service_account.agentless_orchestrate ]
+  project    = local.scanning_project_id
+  secret_id  = google_secret_manager_secret.agentless_orchestrate[0].secret_id
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
+  depends_on = [google_service_account.agentless_orchestrate]
 }
 
 resource "google_secret_manager_secret_iam_member" "member_scan_service_account" {
   count = var.global ? 1 : 0
 
-  project   = local.scanning_project_id
-  secret_id = google_secret_manager_secret.agentless_orchestrate[0].secret_id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${local.agentless_scan_service_account_email}"
-  depends_on = [ google_service_account.agentless_scan ]
+  project    = local.scanning_project_id
+  secret_id  = google_secret_manager_secret.agentless_orchestrate[0].secret_id
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:${local.agentless_scan_service_account_email}"
+  depends_on = [google_service_account.agentless_scan]
 }
 
 // Storage Bucket for Analysis Data
@@ -299,9 +299,9 @@ resource "google_project_iam_member" "agentless_scan" {
 resource "google_cloud_run_v2_job" "agentless_orchestrate" {
   count = var.regional ? 1 : 0
 
-  name         = "${var.prefix}-service-${local.suffix}"
-  location     = local.region
-  project      = local.scanning_project_id
+  name     = "${var.prefix}-service-${local.suffix}"
+  location = local.region
+  project  = local.scanning_project_id
 
   template {
     template {
@@ -371,7 +371,7 @@ resource "google_cloud_run_v2_job" "agentless_orchestrate" {
         dynamic "env" {
           for_each = var.additional_environment_variables
           content {
-            name = env.value["name"]
+            name  = env.value["name"]
             value = env.value["value"]
           }
         }

--- a/output.tf
+++ b/output.tf
@@ -50,6 +50,6 @@ output "suffix" {
 }
 
 output "project_filter_list" {
-  value = local.final_project_filter_list
+  value       = local.final_project_filter_list
   description = "The list of projects to scan in this module."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,10 @@ variable "organization_id" {
   type        = string
   default     = ""
   description = "The organization ID, required if integration_type is set to ORGANIZATION"
+  validation {
+    condition = can(regex("^[0-9]*$", var.organization_id))
+    error_message = "The organization id needs to be a number"
+  }
 }
 
 variable "scanning_project_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -24,8 +24,8 @@ variable "organization_id" {
   default     = ""
   description = "The organization ID, required if integration_type is set to ORGANIZATION"
   validation {
-    condition = can(regex("^[0-9]*$", var.organization_id))
-    error_message = "The organization id needs to be a number"
+    condition     = can(regex("^[0-9]*$", var.organization_id))
+    error_message = "The organization id needs to be a number."
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

It came to my attention that a customer had `organization/<id>` as the `organization_id` in their main.tf and later on had trouble changing it. This PR adds a quick validator to prevent future cases like this.

## How did you test this change?

modify org level multi region example main.tf and run `terraform plan`. observe that invalid organization id was caught.

## Issue

<!--
  Include the link to a Jira/Github issue
-->