### PR TITLE
ci: set minimum TF version for test workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,3 +9,5 @@ jobs:
   call-nightly-workflow:
     uses: lacework/oss-actions/.github/workflows/tf-nightly.yml@main
     secrets: inherit
+    with:
+      tf-version: '["1.4", "1.5"]'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,4 +10,4 @@ jobs:
     uses: lacework/oss-actions/.github/workflows/tf-nightly.yml@main
     secrets: inherit
     with:
-      tf-version: '["1.4", "1.5"]'
+      tf-version: '["1.5"]'

--- a/.github/workflows/test-compat-pr-comment.yml
+++ b/.github/workflows/test-compat-pr-comment.yml
@@ -27,3 +27,5 @@ jobs:
     needs: check-commenting-user
     uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main
     secrets: inherit
+    with:
+      min-version: 1.5

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -11,3 +11,5 @@ jobs:
   call-test-compat:
     uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main
     secrets: inherit
+    with:
+      min-version: 1.4

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -12,4 +12,4 @@ jobs:
     uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main
     secrets: inherit
     with:
-      min-version: 1.4
+      min-version: 1.5


### PR DESCRIPTION
## Summary

This modules requires Terraform 1.4 and higher. Setting test workflow parameters to ensure that tests don't fail due to a lower version being tested. 

## Issue

https://lacework.atlassian.net/browse/GROW-2760