### PR TITLE
ci: fix typo in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,4 +10,4 @@ jobs:
     uses: lacework/oss-actions/.github/workflows/tf-nightly.yml@main
     secrets: inherit
     with:
-      tf-version: '["1.5"]'
+      tf-versions: '["1.5"]'


### PR DESCRIPTION

## Summary

There was a missing character in the input field name. 

## Issue

https://lacework.atlassian.net/browse/GROW-2874