### PR TITLE
misc: add more permissions that are needed for resource group v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.84.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 1.15.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.46 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.18 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.46 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.18 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.84.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 1.15.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -37,7 +37,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | [google_cloud_run_v2_job.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job) | resource |
 | [google_cloud_scheduler_job.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_scheduler_job) | resource |
 | [google_organization_iam_custom_role.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_custom_role.agentless_orchestrate_monitored_project_resource_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
 | [google_organization_iam_member.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_organization_iam_member.agentless_orchestrate_monitored_project_resource_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_project_iam_custom_role.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.agentless_orchestrate_monitored_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.agentless_scan](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |

--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -16,7 +16,20 @@ resource "google_project_iam_custom_role" "agentless_orchestrate_monitored_proje
     "compute.machineTypes.get",
     "compute.zones.list",
     "resourcemanager.projects.get",
-    // Required for Resource Group v2
+  ]
+}
+
+// Scope : MONITORED_PROJECT
+// Use	 : Accessing Folders/Organizations for Resource Group v2
+// Role created at organization
+// Note this binding happens at the organization level because the custom role requires organization level permissions
+resource "google_organization_iam_custom_role" "agentless_orchestrate_monitored_project_resource_group" {
+  count = var.integration_type == "PROJECT" ? 1 : 0
+
+  org_id  = var.organization_id
+  role_id = replace("${var.prefix}-resource-group-${local.suffix}", "-", "_")
+  title   = "Lacework Agentless Workload Scanning Role for monitored project (Resource Group)"
+  permissions = [
     "resourcemanager.folders.get",
     "resourcemanager.organizations.get",
   ]
@@ -46,6 +59,7 @@ resource "google_organization_iam_custom_role" "agentless_orchestrate" {
     "resourcemanager.projects.list",
     // Required for Resource Group v2
     "resourcemanager.organizations.get",
+    "resourcemanager.folders.get",
   ]
 }
 

--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -24,7 +24,7 @@ resource "google_project_iam_custom_role" "agentless_orchestrate_monitored_proje
 // Role created at organization
 // Note this binding happens at the organization level because the custom role requires organization level permissions
 resource "google_organization_iam_custom_role" "agentless_orchestrate_monitored_project_resource_group" {
-  count = var.integration_type == "PROJECT" ? 1 : 0
+  count = var.global && (var.integration_type == "PROJECT") ? 1 : 0
 
   org_id  = var.organization_id
   role_id = replace("${var.prefix}-resource-group-${local.suffix}", "-", "_")

--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -16,6 +16,9 @@ resource "google_project_iam_custom_role" "agentless_orchestrate_monitored_proje
     "compute.machineTypes.get",
     "compute.zones.list",
     "resourcemanager.projects.get",
+    // Required for Resource Group v2
+    "resourcemanager.folders.get",
+    "resourcemanager.organizations.get",
   ]
 }
 
@@ -41,6 +44,8 @@ resource "google_organization_iam_custom_role" "agentless_orchestrate" {
     "compute.zones.list",
     "resourcemanager.folders.list",
     "resourcemanager.projects.list",
+    // Required for Resource Group v2
+    "resourcemanager.organizations.get",
   ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -267,11 +267,11 @@ resource "google_project_iam_member" "agentless_orchestrate_monitored_project" {
   member  = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
 }
 
-// Orchestrate Service Account <-> Role Binding for Custom Role created for project-level integration
+// Orchestrate Service Account <-> Role Binding for Custom Role project-level resource group support
 resource "google_organization_iam_member" "agentless_orchestrate_monitored_project_resource_group" {
-  count = var.integration_type == "PROJECT" ? 1 : 0
+  count = var.global && (var.integration_type == "PROJECT") ? 1 : 0
 
-  org_id = var.organization_id
+  org_id = local.organization_id
   role   = google_organization_iam_custom_role.agentless_orchestrate_monitored_project_resource_group[0].id
   member = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
 }

--- a/main.tf
+++ b/main.tf
@@ -52,27 +52,27 @@ locals {
     The target cloud run job still resides in the desired region.
   */
   unsupported_cloud_scheduler_region_replacements = {
-    us-east5 = "us-east1"
-    us-south1 = "us-central1"
+    us-east5                = "us-east1"
+    us-south1               = "us-central1"
     northamerica-northeast2 = "northamerica-northeast1"
-    southamerica-west1 = "southamerica-east1"
+    southamerica-west1      = "southamerica-east1"
 
     europe-west10 = "europe-west1"
     europe-west12 = "europe-west1"
-    europe-west4 = "europe-west1"
-    europe-west8 = "europe-west1"
-    europe-west9 = "europe-west1"
+    europe-west4  = "europe-west1"
+    europe-west8  = "europe-west1"
+    europe-west9  = "europe-west1"
 
-    europe-north1 = "europe-central2"
+    europe-north1     = "europe-central2"
     europe-southwest1 = "europe-central2"
-    africa-south1 = "europe-central2"
-    me-central1 = "europe-central2"
-    me-central2 = "europe-central2"
-    me-west1 = "europe-central2"
+    africa-south1     = "europe-central2"
+    me-central1       = "europe-central2"
+    me-central2       = "europe-central2"
+    me-west1          = "europe-central2"
 
-    asia-south2 = "asia-south1"
+    asia-south2          = "asia-south1"
     australia-southeast2 = "australia-southeast1"
-}
+  }
   cloud_scheduler_region = lookup(local.unsupported_cloud_scheduler_region_replacements, local.region, local.region)
 }
 
@@ -267,6 +267,15 @@ resource "google_project_iam_member" "agentless_orchestrate_monitored_project" {
   member  = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
 }
 
+// Orchestrate Service Account <-> Role Binding for Custom Role created for project-level integration
+resource "google_organization_iam_member" "agentless_orchestrate_monitored_project_resource_group" {
+  count = var.integration_type == "PROJECT" ? 1 : 0
+
+  org_id = var.organization_id
+  role   = google_organization_iam_custom_role.agentless_orchestrate_monitored_project_resource_group[0].id
+  member = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
+}
+
 // Orchestrate Service Account <-> Role Binding for Custom Role created in Scanner Project
 resource "google_project_iam_member" "agentless_orchestrate" {
   count = var.global ? 1 : 0
@@ -429,9 +438,9 @@ resource "google_cloud_scheduler_job" "agentless_orchestrate" {
   description = "Invoke Lacework Agentless Workload Scanning on a schedule."
   project     = local.scanning_project_id
   // for unsupported regions, cloud scheduler is configured in a different region
-  region      = local.cloud_scheduler_region
-  schedule    = "0 * * * *"
-  time_zone   = "Etc/UTC"
+  region    = local.cloud_scheduler_region
+  schedule  = "0 * * * *"
+  time_zone = "Etc/UTC"
 
   http_target {
     http_method = "POST"
@@ -454,7 +463,7 @@ resource "terraform_data" "execute_cloud_run_job" {
   }
 
   provisioner "local-exec" {
-    command = "gcloud run jobs execute ${ google_cloud_run_v2_job.agentless_orchestrate[0].name } --region=${ local.region }"
+    command = "gcloud run jobs execute ${google_cloud_run_v2_job.agentless_orchestrate[0].name} --region=${local.region}"
   }
 
   depends_on = [google_cloud_run_v2_job.agentless_orchestrate]


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

To support RG v2, we'll need to query for folder and organization information. That entails the following perms:
* resourcemanager.folders.get
* resourcemanager.organizations.get

This PR adds those two perms. For org-level integration this is trivial, because I can just add those two permissions to the existing perm list. For project-level integration I need to create a separate org-level custom role, because those two permissions only exist at org-level and GCP wouldn't allow you to add those perms to a project-level role.

Happy to hear suggestions on better implementations.

Related PR: https://github.com/lacework-dev/sidekick/pull/1094 

## How did you test this change?

deployed with both `org-level-multi-region` and `project-level-multi-region` examples and inspect analyze.ndjson files to verify that tags are generated correctly. Screenshots:

* org-level
<img width="382" alt="Screenshot 2024-05-14 at 3 09 44 PM" src="https://github.com/lacework/terraform-gcp-agentless-scanning/assets/3220644/178f0bb3-a6bb-4762-820b-772c29fcb2c0">


* project-level

## Issue

https://lacework.atlassian.net/browse/LINK-2695