### PR TITLE
misc: use organization_id smarter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.46 |
 | <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.18 |
 
@@ -19,9 +19,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.84.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 1.15.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.46 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.18 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.46 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.18 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.84.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 1.15.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -37,7 +37,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | [google_cloud_run_v2_job.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job) | resource |
 | [google_cloud_scheduler_job.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_scheduler_job) | resource |
 | [google_organization_iam_custom_role.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_custom_role.agentless_orchestrate_monitored_project_resource_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
 | [google_organization_iam_member.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_organization_iam_member.agentless_orchestrate_monitored_project_resource_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_project_iam_custom_role.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.agentless_orchestrate_monitored_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.agentless_scan](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |

--- a/checks.tf
+++ b/checks.tf
@@ -1,0 +1,10 @@
+// ensure that organization_id is not empty, even for project-level integrations
+check "non_empty_organization_id" {
+  // There can be multiple reasons for an empty `organization_id`. One example is that the provider project resides
+  // in a folder. In this case, google_project.selected[0].org_id will be empty whereas google_project.selected[0].folder_id
+  // will be non-empty. We'd need to ask the user to provide the organization_id in such cases.
+  assert {
+    condition     = local.organization_id != ""
+    error_message = "No `organization_id` is provided and we failed to derive one. Please provide `organization_id`."
+  }
+}

--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -44,7 +44,7 @@ resource "google_organization_iam_custom_role" "agentless_orchestrate" {
   count = var.global && (var.integration_type == "ORGANIZATION") ? 1 : 0
 
   role_id = replace("${var.prefix}-snapshot-${local.suffix}", "-", "_")
-  org_id  = var.organization_id
+  org_id  = local.organization_id
   title   = "Lacework Agentless Workload Scanning Role for monitored organization (Organization Snapshots)"
   permissions = [
     "iam.roles.get",

--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -16,7 +16,20 @@ resource "google_project_iam_custom_role" "agentless_orchestrate_monitored_proje
     "compute.machineTypes.get",
     "compute.zones.list",
     "resourcemanager.projects.get",
-    // Required for Resource Group v2
+  ]
+}
+
+// Scope : MONITORED_PROJECT
+// Use	 : Accessing Folders/Organizations for Resource Group v2
+// Role created at organization
+// Note this binding happens at the organization level because the custom role requires organization level permissions
+resource "google_organization_iam_custom_role" "agentless_orchestrate_monitored_project_resource_group" {
+  count = var.integration_type == "PROJECT" ? 1 : 0
+
+  org_id  = var.organization_id
+  role_id = replace("${var.prefix}-resource-group-${local.suffix}", "-", "_")
+  title   = "Lacework Agentless Workload Scanning Role for monitored project (Resource Group)"
+  permissions = [
     "resourcemanager.folders.get",
     "resourcemanager.organizations.get",
   ]
@@ -46,6 +59,7 @@ resource "google_organization_iam_custom_role" "agentless_orchestrate" {
     "resourcemanager.projects.list",
     // Required for Resource Group v2
     "resourcemanager.organizations.get",
+    "resourcemanager.folders.get",
   ]
 }
 

--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -24,7 +24,7 @@ resource "google_project_iam_custom_role" "agentless_orchestrate_monitored_proje
 // Role created at organization
 // Note this binding happens at the organization level because the custom role requires organization level permissions
 resource "google_organization_iam_custom_role" "agentless_orchestrate_monitored_project_resource_group" {
-  count = var.integration_type == "PROJECT" ? 1 : 0
+  count = var.global && (var.integration_type == "PROJECT") ? 1 : 0
 
   org_id  = var.organization_id
   role_id = replace("${var.prefix}-resource-group-${local.suffix}", "-", "_")

--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -26,7 +26,7 @@ resource "google_project_iam_custom_role" "agentless_orchestrate_monitored_proje
 resource "google_organization_iam_custom_role" "agentless_orchestrate_monitored_project_resource_group" {
   count = var.global && (var.integration_type == "PROJECT") ? 1 : 0
 
-  org_id  = var.organization_id
+  org_id  = local.organization_id
   role_id = replace("${var.prefix}-resource-group-${local.suffix}", "-", "_")
   title   = "Lacework Agentless Workload Scanning Role for monitored project (Resource Group)"
   permissions = [

--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -16,6 +16,9 @@ resource "google_project_iam_custom_role" "agentless_orchestrate_monitored_proje
     "compute.machineTypes.get",
     "compute.zones.list",
     "resourcemanager.projects.get",
+    // Required for Resource Group v2
+    "resourcemanager.folders.get",
+    "resourcemanager.organizations.get",
   ]
 }
 
@@ -41,6 +44,8 @@ resource "google_organization_iam_custom_role" "agentless_orchestrate" {
     "compute.zones.list",
     "resourcemanager.folders.list",
     "resourcemanager.projects.list",
+    // Required for Resource Group v2
+    "resourcemanager.organizations.get",
   ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -267,11 +267,11 @@ resource "google_project_iam_member" "agentless_orchestrate_monitored_project" {
   member  = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
 }
 
-// Orchestrate Service Account <-> Role Binding for Custom Role created for project-level integration
+// Orchestrate Service Account <-> Role Binding for Custom Role project-level resource group support
 resource "google_organization_iam_member" "agentless_orchestrate_monitored_project_resource_group" {
-  count = var.integration_type == "PROJECT" ? 1 : 0
+  count = var.global && (var.integration_type == "PROJECT") ? 1 : 0
 
-  org_id = var.organization_id
+  org_id = local.organization_id
   role   = google_organization_iam_custom_role.agentless_orchestrate_monitored_project_resource_group[0].id
   member = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
 }

--- a/main.tf
+++ b/main.tf
@@ -52,27 +52,27 @@ locals {
     The target cloud run job still resides in the desired region.
   */
   unsupported_cloud_scheduler_region_replacements = {
-    us-east5 = "us-east1"
-    us-south1 = "us-central1"
+    us-east5                = "us-east1"
+    us-south1               = "us-central1"
     northamerica-northeast2 = "northamerica-northeast1"
-    southamerica-west1 = "southamerica-east1"
+    southamerica-west1      = "southamerica-east1"
 
     europe-west10 = "europe-west1"
     europe-west12 = "europe-west1"
-    europe-west4 = "europe-west1"
-    europe-west8 = "europe-west1"
-    europe-west9 = "europe-west1"
+    europe-west4  = "europe-west1"
+    europe-west8  = "europe-west1"
+    europe-west9  = "europe-west1"
 
-    europe-north1 = "europe-central2"
+    europe-north1     = "europe-central2"
     europe-southwest1 = "europe-central2"
-    africa-south1 = "europe-central2"
-    me-central1 = "europe-central2"
-    me-central2 = "europe-central2"
-    me-west1 = "europe-central2"
+    africa-south1     = "europe-central2"
+    me-central1       = "europe-central2"
+    me-central2       = "europe-central2"
+    me-west1          = "europe-central2"
 
-    asia-south2 = "asia-south1"
+    asia-south2          = "asia-south1"
     australia-southeast2 = "australia-southeast1"
-}
+  }
   cloud_scheduler_region = lookup(local.unsupported_cloud_scheduler_region_replacements, local.region, local.region)
 }
 
@@ -267,6 +267,15 @@ resource "google_project_iam_member" "agentless_orchestrate_monitored_project" {
   member  = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
 }
 
+// Orchestrate Service Account <-> Role Binding for Custom Role created for project-level integration
+resource "google_organization_iam_member" "agentless_orchestrate_monitored_project_resource_group" {
+  count = var.integration_type == "PROJECT" ? 1 : 0
+
+  org_id = var.organization_id
+  role   = google_organization_iam_custom_role.agentless_orchestrate_monitored_project_resource_group[0].id
+  member = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
+}
+
 // Orchestrate Service Account <-> Role Binding for Custom Role created in Scanner Project
 resource "google_project_iam_member" "agentless_orchestrate" {
   count = var.global ? 1 : 0
@@ -429,9 +438,9 @@ resource "google_cloud_scheduler_job" "agentless_orchestrate" {
   description = "Invoke Lacework Agentless Workload Scanning on a schedule."
   project     = local.scanning_project_id
   // for unsupported regions, cloud scheduler is configured in a different region
-  region      = local.cloud_scheduler_region
-  schedule    = "0 * * * *"
-  time_zone   = "Etc/UTC"
+  region    = local.cloud_scheduler_region
+  schedule  = "0 * * * *"
+  time_zone = "Etc/UTC"
 
   http_target {
     http_method = "POST"
@@ -454,7 +463,7 @@ resource "terraform_data" "execute_cloud_run_job" {
   }
 
   provisioner "local-exec" {
-    command = "gcloud run jobs execute ${ google_cloud_run_v2_job.agentless_orchestrate[0].name } --region=${ local.region }"
+    command = "gcloud run jobs execute ${google_cloud_run_v2_job.agentless_orchestrate[0].name} --region=${local.region}"
   }
 
   depends_on = [google_cloud_run_v2_job.agentless_orchestrate]

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 1.5"
 
   required_providers {
     google = "~> 4.46"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

While working on #74 I noticed that `organization_id` isn't consistently set, so I went through all the example files and ensured it's used in a consistent way. In details:
1. if `organization_id` is not provided, we try to derive it w/ the provider `project_id`
2. we fail to do that, we warn users 
3. in places where `organization_id` is used, we consistently use the derived `local.organization_id` instead of user-provided `var.organization_id`. 

I also updated the min version requirements because minimum TF 1.5 is needed to support `checks` block. This makes it consistent w/ the Azure TF repo. 

## How did you test this change?

1. Go through all example main.tf, add a valid provider project_id, and observe `terraform apply` goes through.
2. Remove project_id and observe `checks` kick in

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

https://lacework.atlassian.net/browse/LINK-2695