### PR TITLE
chore: upgrade gcp version requirements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -221,7 +221,7 @@ module "lacework_agentless_scan_svc_account" {
   count = var.global ? 1 : 0
 
   source               = "lacework/service-account/gcp"
-  version              = "~> 1.0"
+  version              = "~> 2.0"
   create               = true
   service_account_name = local.lacework_integration_service_account_name
   project_id           = local.scanning_project_id

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.5"
 
   required_providers {
-    google = "~> 4.46"
+    google = ">= 4.46"
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.18"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

google provider 5.0 is needed by some customers. This PR removes the patch version requirement so `>=4.46` can be used.

It's worth noting that we used to depend on major version `1.0` of `lacework/service-account/gcp`. However, it has a google provider requirements of `< 5.0`. The constraint got removed in https://github.com/lacework/terraform-gcp-service-account/pull/45 and released in major version `2.0`, so I needed to upgrade this requirement as well. 

I am not a versioning expert and do worry about this upgrade causing breakages. Would love some reviews/recommendations. 

## How did you test this change?

Force the latest version of google provider (v5.29.1) and run terraform on `org-level-multi-region` and `custom-vpc-network` to ensure deployment happen correctly.

side observation: us-central1 is experiencing cryptic "internal error" and "code 13" upon deployment of cloud run jobs. I got the deployment working after switching to us-west1. 

## Issue

<!--
  Include the link to a Jira/Github issue
-->