### PR TITLE
fix: use right resource id in project-level intg

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ resource "lacework_integration_gcp_agentless_scanning" "lacework_cloud_account" 
 
   name                   = var.lacework_integration_name
   resource_level         = var.integration_type
-  resource_id            = length(local.organization_id) > 0 ? local.organization_id : local.scanning_project_id
+  resource_id            = var.integration_type == "ORGANIZATION" ? local.organization_id : local.scanning_project_id
   bucket_name            = google_storage_bucket.lacework_bucket[0].name
   scanning_project_id    = local.scanning_project_id
   filter_list            = local.final_project_filter_list


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Upon manual inspection, I noticed this condition wasn't quite right given #75. The side-effect of #75 is that we'd expect even project-level integration to have an organization id. However, this would break the assumption in this condition.

This PR corrected the condition (and also made the intention explicit). 

## How did you test this change?

Deploy onto two examples:
`project-level-multi-region`, and `org-level-multi-region`. Observe the resource_id gets corrected in the former, whereas not changes in the latter.

## Issue

<!--
  Include the link to a Jira/Github issue
-->