### PR TITLE
chore: update version and add org_id in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.84.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 1.15.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.46 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.19 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.46 |
-| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.18 |
+| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.19 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.46 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.18 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.84.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 1.15.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/examples/custom-vpc-network/main.tf
+++ b/examples/custom-vpc-network/main.tf
@@ -69,12 +69,13 @@ module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
 
   project_filter_list = local.project_filter_list
 
-  global   = true
-  regional = true
+  global          = true
+  regional        = true
+  organization_id = "your_organization_id"
 
   custom_vpc_subnet = google_compute_subnetwork.awls_subnet_1.id
   # example: passing an environment variable to the cloud run task
-  additional_environment_variables = [{name="EXAMPLE_ENV_VAR", value="something"}]
+  additional_environment_variables = [{ name = "EXAMPLE_ENV_VAR", value = "something" }]
 }
 
 module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
@@ -84,11 +85,13 @@ module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
     google = google.usc1
   }
 
-  regional                = true
+  regional        = true
+  organization_id = "your_organization_id"
+
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1
 
   custom_vpc_subnet = google_compute_subnetwork.awls_subnet_2.id
 
   # example: how to pass an environment variable to a cloud task
-  additional_environment_variables = [{name="EXAMPLE_ENV_VAR", value="something"}]
+  additional_environment_variables = [{ name = "EXAMPLE_ENV_VAR", value = "something" }]
 }

--- a/examples/custom-vpc-network/main.tf
+++ b/examples/custom-vpc-network/main.tf
@@ -71,7 +71,7 @@ module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
 
   global          = true
   regional        = true
-  organization_id = "your_organization_id"
+  organization_id = "1234567890"
 
   custom_vpc_subnet = google_compute_subnetwork.awls_subnet_1.id
   # example: passing an environment variable to the cloud run task
@@ -86,7 +86,7 @@ module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
   }
 
   regional        = true
-  organization_id = "your_organization_id"
+  organization_id = "1234567890"
 
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1
 

--- a/examples/custom-vpc-network/versions.tf
+++ b/examples/custom-vpc-network/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.5"
 
   required_providers {
     lacework = {

--- a/examples/org-level-multi-region/versions.tf
+++ b/examples/org-level-multi-region/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.5"
 
   required_providers {
     lacework = {

--- a/examples/org-level-single-region/versions.tf
+++ b/examples/org-level-single-region/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.5"
 
   required_providers {
     lacework = {

--- a/examples/project-level-multi-region/main.tf
+++ b/examples/project-level-multi-region/main.tf
@@ -26,8 +26,10 @@ module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
 
   project_filter_list = local.project_filter_list
 
-  global                    = true
-  regional                  = true
+  global          = true
+  regional        = true
+  organization_id = "your_organization_id"
+
   lacework_integration_name = "agentless_from_terraform"
 }
 
@@ -38,6 +40,8 @@ module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
     google = google.usc1
   }
 
-  regional                = true
+  regional        = true
+  organization_id = "your_organization_id"
+
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1
 }

--- a/examples/project-level-multi-region/main.tf
+++ b/examples/project-level-multi-region/main.tf
@@ -28,7 +28,7 @@ module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
 
   global          = true
   regional        = true
-  organization_id = "your_organization_id"
+  organization_id = "1234567890"
 
   lacework_integration_name = "agentless_from_terraform"
 }
@@ -41,7 +41,7 @@ module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
   }
 
   regional        = true
-  organization_id = "your_organization_id"
+  organization_id = "1234567890"
 
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1
 }

--- a/examples/project-level-multi-region/versions.tf
+++ b/examples/project-level-multi-region/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.5"
 
   required_providers {
     lacework = {

--- a/examples/project-level-single-region/main.tf
+++ b/examples/project-level-single-region/main.tf
@@ -14,7 +14,7 @@ module "lacework_gcp_agentless_scanning_project_single_region" {
 
   global          = true
   regional        = true
-  organization_id = "your_organization_id"
+  organization_id = "1234567890"
 
   lacework_integration_name = "agentless_from_terraform"
 }

--- a/examples/project-level-single-region/main.tf
+++ b/examples/project-level-single-region/main.tf
@@ -12,7 +12,9 @@ module "lacework_gcp_agentless_scanning_project_single_region" {
     "monitored-project-2"
   ]
 
-  global                    = true
-  regional                  = true
+  global          = true
+  regional        = true
+  organization_id = "your_organization_id"
+
   lacework_integration_name = "agentless_from_terraform"
 }

--- a/examples/project-level-single-region/versions.tf
+++ b/examples/project-level-single-region/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.5"
 
   required_providers {
     lacework = {

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
     google = ">= 4.46"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 1.18"
+      version = "~> 1.19"
     }
   }
 }


### PR DESCRIPTION

## Summary

Per discussion on Slack, we need this version updated and also include `organization_id` for project-level integration because we need to support the creation of an additional role (#74 ). Sometimes the `organization_id` can't be inferred, so in our example we explicitly include it.

## How did you test this change?

deploy example tf files and observe it works.

## Issue

