### PR TITLE
fix(AWLS2-398): Add get project permission to org snapshot role

### DIFF
--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -60,6 +60,7 @@ resource "google_organization_iam_custom_role" "agentless_orchestrate" {
     // Required for Resource Group v2
     "resourcemanager.organizations.get",
     "resourcemanager.folders.get",
+    "resourcemanager.projects.get",
   ]
 }
 


### PR DESCRIPTION
## Summary

**Add permission required by org-level agentless scanning integration to call the GCP Get Project API.**

https://github.com/lacework/terraform-gcp-agentless-scanning/pull/52 modified the _Lacework Agentless Workload Scanning Role for monitored project (Create Snapshots)_, adding a required permission used to call Get Project GCP API. This resolved an issue in the case of project-level agentless scanning integrations, but the issue is still present in the case of org-level agentless scanning integrations. 

The same permission should've also been added to the role used by org-level integrations in that PR, but it wasn't — this PR adds the required permission in that role to resolve the issue in the case of org-level integrations as well.

## How did you test this change?

Prior to this change, we were seeing the get project call fail with a permission error — [these logs](https://ui.honeycomb.io/lacework/datasets/agentless-sidekick-prod/result/4pwgZ3Yw75H) show that this issue occurs for several customers.

I ran `terraform apply` with my changes to add the permission for my org-level integration deployed against [tn-dev.qan.corp.lacework.net](https://tn-dev.qan.corp.lacework.net/), and once the change took effect, logs showed that the calls to get project were succeeding rather than failing ([ref](https://ui.honeycomb.io/lacework/datasets/sidekick-dev/result/zU1PfVRBBpy?hideCompare)). 

## Issue

[AWLS2-398](https://lacework.atlassian.net/browse/AWLS2-398)

[AWLS2-398]: https://lacework.atlassian.net/browse/AWLS2-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ