### PR TITLE
fix: update Terraform examples

### DIFF
--- a/examples/custom-vpc-network/README.md
+++ b/examples/custom-vpc-network/README.md
@@ -11,18 +11,48 @@ In this example we add Terraform modules to two Google Cloud regions.
   - Cloud Scheduler Job
 
 ## Sample Code
-
+Define your `versions.tf` as follows:
 ```hcl
-provider "lacework" {}
+terraform {
+  required_version = ">= 1.5"
 
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+    }
+  }
+}
+```
+
+Define your `main.tf` as follows:
+```hcl
+# Set your Lacework profile here. With the Lacework CLI, use 
+# `lacework configure list` to get a list of available profiles.
+provider "lacework" {
+  profile = "lw_agentless"
+}
+
+/*
+This provider will be used to deploy AWLS's global scanning resources. As such, it must be assigned as
+the provider in the per-region AWLS module block where `global == true`. 
+For reference, see module "lacework_gcp_agentless_scanning_project_multi_region_<alias1>", which
+has `global = true` and therefore is where we set this provider as the google provider.
+*/
 provider "google" {
-  alias  = "use1"
-  region = "us-east1"
+  alias  = <alias1>
+  region = <region1>
+  # Set the project in which the scanning resources will be hosted.
+  project = <your-project-id>
 }
 
 provider "google" {
-  alias  = "usc1"
-  region = "us-central1"
+  alias  = <alias2>
+  region = <region2>
+
+  # Set your default project ID for this region. This isn't required for
+  # the Agentless integration, but is required by the Google Provider.
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started#configuring-the-provider
+  project = "default-project-id"
 }
 
 locals {
@@ -75,32 +105,34 @@ resource "google_compute_firewall" "rules" {
   }
 }
 
-module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
+module "lacework_gcp_agentless_scanning_project_multi_region_<alias1>" {
   source  = "lacework/agentless-scanning/gcp"
-  version = "~> 0.1"
+  version = "~> 2.0"
 
   providers = {
-    google = google.use1
+    google = google.<alias1>
   }
 
   project_filter_list = local.project_filter_list
 
+  organization_id  = <your-org-id>
   global                    = true
   regional                  = true
 
   custom_vpc_subnet = google_compute_subnetwork.awls_subnet_1.id
 }
 
-module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
+module "lacework_gcp_agentless_scanning_project_multi_region_<alias2>" {
   source  = "lacework/agentless-scanning/gcp"
-  version = "~> 0.1"
+  version = "~> 2.0"
 
   providers = {
-    google = google.usc1
+    google = google.<alias2>
   }
 
   project_filter_list = local.project_filter_list
 
+  organization_id  = <your-org-id>
   regional                = true
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1
 

--- a/examples/org-level-single-region/README.md
+++ b/examples/org-level-single-region/README.md
@@ -12,17 +12,51 @@ In this example we add Terraform modules to one Google Cloud region.
 
 ## Sample Code
 
+Define your `versions.tf` as follows:
 ```hcl
-provider "lacework" {}
+terraform {
+  required_version = ">= 1.5"
 
-provider "google" {}
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+    }
+  }
+}
+```
+
+Define your `main.tf` as follows:
+```hcl
+# Set your Lacework profile here. With the Lacework CLI, use 
+# `lacework configure list` to get a list of available profiles.
+provider "lacework" {
+  profile = "lw_agentless"
+}
+
+provider "google" {
+  # Set the ID of the project where the scanning resources are hosted.
+  project = <your-project-id>
+
+  # Set the region where the scanning resources are hosted.
+  region = <region>
+}
 
 module "lacework_gcp_agentless_scanning_org_single_region" {
   source  = "lacework/agentless-scanning/gcp"
-  version = "~> 0.1"
+  version = "~> 2.0"
+
+  # Provide a list of Google Cloud projects and/or folders that you want to monitor here.
+  # For projects, enter the project ID. 
+  # If the project_filter_list is omitted, all projects and folders in the organization are scanned.
+  #project_filter_list = [
+  #  "monitored-project-1",
+  #  "monitored-project-2",
+  #  "folder/monitored-folder-1",
+  #  "folder/monitored-folder-2
+  #]
 
   integration_type = "ORGANIZATION"
-  organization_id  = "123456789012"
+  organization_id  = <your-org-id>
 
   global                    = true
   regional                  = true

--- a/examples/project-level-multi-region/README.md
+++ b/examples/project-level-multi-region/README.md
@@ -12,27 +12,60 @@ In this example we add Terraform modules to two Google Cloud regions.
 
 ## Sample Code
 
+Define your `versions.tf` as follows:
 ```hcl
-provider "lacework" {}
+terraform {
+  required_version = ">= 1.5"
 
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+    }
+  }
+}
+```
+
+Define your `main.tf` as follows:
+```hcl
+# Set your Lacework profile here. With the Lacework CLI, use 
+# `lacework configure list` to get a list of available profiles.
+provider "lacework" {
+  profile = "lw_agentless"
+}
+
+/*
+This provider will be used to deploy AWLS's global scanning resources. As such, it must be assigned as
+the provider in the per-region AWLS module block where `global == true`. 
+For reference, see module "lacework_gcp_agentless_scanning_project_multi_region_<alias1>", which
+has `global = true` and therefore is where we set this provider as the google provider.
+*/
 provider "google" {
-  alias  = "use1"
-  region = "us-east1"
+  alias  = <alias1>
+  region = <region1>
+  # Set the project in which the scanning resources will be hosted.
+  project = <your-project-id>
 }
 
 provider "google" {
-  alias  = "usc1"
-  region = "us-central1"
+  alias  = <alias2>
+  region = <region2>
+
+  # Set your default project ID for this region. This isn't required for
+  # the Agentless integration, but is required by the Google Provider.
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started#configuring-the-provider
+  project = "default-project-id"
 }
 
-module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
+module "lacework_gcp_agentless_scanning_project_multi_region_<alias1>" {
   source  = "lacework/agentless-scanning/gcp"
-  version = "~> 0.1"
+  version = "~> 2.0"
 
   providers = {
-    google = google.use1
+    google = google.<alias1>
   }
 
+  # Provide the list of Google Cloud projects that you want to monitor here.
+  # Enter the ID of the projects.
   project_filter_list = [
     "monitored-project-1",
     "monitored-project-2"
@@ -40,18 +73,20 @@ module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
 
   global                    = true
   regional                  = true
+  organization_id           = <your-org-id>
   lacework_integration_name = "agentless_from_terraform"
 }
 
-module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
+module "lacework_gcp_agentless_scanning_project_multi_region_<alias2>" {
   source  = "lacework/agentless-scanning/gcp"
-  version = "~> 0.1"
+  version = "~> 2.0"
 
   providers = {
     google = google.usc1
   }
 
   regional                = true
-  global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1
+  organization_id         = <your-org-id>
+  global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_<alias1>
 }
 ```

--- a/examples/project-level-single-region/README.md
+++ b/examples/project-level-single-region/README.md
@@ -12,15 +12,41 @@ In this example we add Terraform modules to one Google Cloud region.
 
 ## Sample Code
 
+Define your `versions.tf` as follows:
 ```hcl
-provider "lacework" {}
+terraform {
+  required_version = ">= 1.5"
 
-provider "google" {}
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+    }
+  }
+}
+```
+
+Define your `main.tf` as follows:
+```hcl
+# Set your Lacework profile here. With the Lacework CLI, use 
+# `lacework configure list` to get a list of available profiles.
+provider "lacework" {
+  profile = "lw_agentless"
+}
+
+provider "google" {
+  # Set the ID of the project where the scanning resources are hosted.
+  project = <your-project-id>
+
+  # Set the region where the scanning resources are hosted.
+  region = <region>
+}
 
 module "lacework_gcp_agentless_scanning_project_single_region" {
   source  = "lacework/agentless-scanning/gcp"
-  version = "~> 0.1"
+  version = "~> 2.0"
 
+  # Provide the list of Google Cloud projects that you want to monitor here.
+  # Enter the ID of the projects.
   project_filter_list = [
     "monitored-project-1",
     "monitored-project-2"
@@ -28,6 +54,7 @@ module "lacework_gcp_agentless_scanning_project_single_region" {
 
   global                    = true
   regional                  = true
+  organization_id           = <your-org-id>
   lacework_integration_name = "agentless_from_terraform"
 }
 ```


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

The examples in this repo were a bit out of date, and they no longer match the examples given in the Fortinet documentation. This PR cleans things up. In particular, this changeset:
1. Updates the README examples to contain an up-to-date `versions.tf`
2. Updates the google TF provider to contain a `project` field, since this is now required
3. Adds annotations to explain certain variables and options, where appropriate.
4. Adds the "organization ID" to project level example READMEs, since this is now a required field for project level integrations. The examples themselves already contained these fields.

Special focus was given to getting the README files up-to-date since in the near future, the Fortinet documentation won't contain Terraform examples at all; the docs will simply point to these READMEs on https://registry.terraform.io/modules/lacework/agentless-scanning/gcp/latest. 

## How did you test this change?

I test deployed both a project level and and organization level integration using the examples with these changes in place. In both cases, `terraform apply` was successful and the integration appears properly configured.


## Issue
https://lacework.atlassian.net/browse/AWLS2-550