### PR TITLE
fix(LINK-4116): do not require org level permissions for project level integrations.

### DIFF
--- a/checks.tf
+++ b/checks.tf
@@ -1,10 +1,9 @@
-// ensure that organization_id is not empty, even for project-level integrations
 check "non_empty_organization_id" {
   // There can be multiple reasons for an empty `organization_id`. One example is that the provider project resides
   // in a folder. In this case, google_project.selected[0].org_id will be empty whereas google_project.selected[0].folder_id
   // will be non-empty. We'd need to ask the user to provide the organization_id in such cases.
   assert {
-    condition     = local.organization_id != ""
+    condition     = local.organization_id != "" && local.integration_type == "ORGANIZATION"
     error_message = "No `organization_id` is provided and we failed to derive one. Please provide `organization_id`."
   }
 }

--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -19,22 +19,6 @@ resource "google_project_iam_custom_role" "agentless_orchestrate_monitored_proje
   ]
 }
 
-// Scope : MONITORED_PROJECT
-// Use	 : Accessing Folders/Organizations for Resource Group v2
-// Role created at organization
-// Note this binding happens at the organization level because the custom role requires organization level permissions
-resource "google_organization_iam_custom_role" "agentless_orchestrate_monitored_project_resource_group" {
-  count = var.global && (var.integration_type == "PROJECT") ? 1 : 0
-
-  org_id  = local.organization_id
-  role_id = replace("${var.prefix}-resource-group-${local.suffix}", "-", "_")
-  title   = "Lacework Agentless Workload Scanning Role for monitored project (Resource Group)"
-  permissions = [
-    "resourcemanager.folders.get",
-    "resourcemanager.organizations.get",
-  ]
-}
-
 //-----------------------------------------------------------------------------------
 
 // Scope : MONITORED_ORGANIZATION

--- a/examples/custom-vpc-network/README.md
+++ b/examples/custom-vpc-network/README.md
@@ -115,7 +115,6 @@ module "lacework_gcp_agentless_scanning_project_multi_region_<alias1>" {
 
   project_filter_list = local.project_filter_list
 
-  organization_id  = <your-org-id>
   global                    = true
   regional                  = true
 
@@ -132,7 +131,6 @@ module "lacework_gcp_agentless_scanning_project_multi_region_<alias2>" {
 
   project_filter_list = local.project_filter_list
 
-  organization_id  = <your-org-id>
   regional                = true
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1
 

--- a/examples/custom-vpc-network/main.tf
+++ b/examples/custom-vpc-network/main.tf
@@ -71,7 +71,6 @@ module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
 
   global          = true
   regional        = true
-  organization_id = "1234567890"
 
   custom_vpc_subnet = google_compute_subnetwork.awls_subnet_1.id
   # example: passing an environment variable to the cloud run task
@@ -86,7 +85,6 @@ module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
   }
 
   regional        = true
-  organization_id = "1234567890"
 
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1
 

--- a/examples/project-level-multi-region/README.md
+++ b/examples/project-level-multi-region/README.md
@@ -73,7 +73,6 @@ module "lacework_gcp_agentless_scanning_project_multi_region_<alias1>" {
 
   global                    = true
   regional                  = true
-  organization_id           = <your-org-id>
   lacework_integration_name = "agentless_from_terraform"
 }
 
@@ -86,7 +85,6 @@ module "lacework_gcp_agentless_scanning_project_multi_region_<alias2>" {
   }
 
   regional                = true
-  organization_id         = <your-org-id>
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_<alias1>
 }
 ```

--- a/examples/project-level-multi-region/main.tf
+++ b/examples/project-level-multi-region/main.tf
@@ -28,7 +28,6 @@ module "lacework_gcp_agentless_scanning_project_multi_region_use1" {
 
   global          = true
   regional        = true
-  organization_id = "1234567890"
 
   lacework_integration_name = "agentless_from_terraform"
 }
@@ -41,7 +40,6 @@ module "lacework_gcp_agentless_scanning_project_multi_region_usc1" {
   }
 
   regional        = true
-  organization_id = "1234567890"
 
   global_module_reference = module.lacework_gcp_agentless_scanning_project_multi_region_use1
 }

--- a/examples/project-level-single-region/README.md
+++ b/examples/project-level-single-region/README.md
@@ -54,7 +54,6 @@ module "lacework_gcp_agentless_scanning_project_single_region" {
 
   global                    = true
   regional                  = true
-  organization_id           = <your-org-id>
   lacework_integration_name = "agentless_from_terraform"
 }
 ```

--- a/examples/project-level-single-region/main.tf
+++ b/examples/project-level-single-region/main.tf
@@ -14,7 +14,6 @@ module "lacework_gcp_agentless_scanning_project_single_region" {
 
   global          = true
   regional        = true
-  organization_id = "1234567890"
 
   lacework_integration_name = "agentless_from_terraform"
 }

--- a/main.tf
+++ b/main.tf
@@ -269,15 +269,6 @@ resource "google_project_iam_member" "agentless_orchestrate_monitored_project" {
   member  = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
 }
 
-// Orchestrate Service Account <-> Role Binding for Custom Role project-level resource group support
-resource "google_organization_iam_member" "agentless_orchestrate_monitored_project_resource_group" {
-  count = var.global && (local.integration_type == "PROJECT") ? 1 : 0
-
-  org_id = local.organization_id
-  role   = google_organization_iam_custom_role.agentless_orchestrate_monitored_project_resource_group[0].id
-  member = "serviceAccount:${local.agentless_orchestrate_service_account_email}"
-}
-
 // Orchestrate Service Account <-> Role Binding for Custom Role created in Scanner Project
 resource "google_project_iam_member" "agentless_orchestrate" {
   count = var.global ? 1 : 0


### PR DESCRIPTION
## Summary

We have a reported customer issue where deploying a project-level GCP integration requires org-level permissions. 

This happens due to a change from about a year back (https://github.com/lacework/terraform-gcp-agentless-scanning/pull/74) that requires us to have `resourcemanager.organizations.get` permissions for both project and organization level integrations. Our docs make no mention of this in the "required permissions" list.

The reasoning behind this was that ideally we will report the org ID for all integrations so that UI views are more complete. However, this is a relatively minor piece of information and for many customers requiring org level permissions for a project level integration is a non-starter. It defeats the purposes in many cases.

As a consequence, I think it's best if we revert that change. Yes, we will not be able to get the org ID. But at least customers who need a project level integration due to a lack of org/root level permissions will be able to deploy without issue.

I also toyed with the idea of providing an override option instead of just eliminating the org permissions outright, but I felt that it makes for an unnecessarily convoluted deployment experience. Simpler to just remove it.


## How did you test this change?
I deployed a project level integration without specifying an organization ID. My role did not have org level permissions and the deployment still worked fine. 

## Issue
https://lacework.atlassian.net/browse/LINK-4116