### PR TITLE
fix: add option for git whatchanged

### DIFF
--- a/scripts/release_helpers.sh
+++ b/scripts/release_helpers.sh
@@ -88,7 +88,7 @@ git_add_version_files() {
 
 verify_release() {
   log "verifying new release"
-  _changed_file=$(git whatchanged --name-only --pretty="" origin..HEAD)
+  _changed_file=$(git whatchanged --i-still-use-this --name-only --pretty="" origin..HEAD)
   for f in "${required_files_for_release[@]}"; do
     if [[ "$_changed_file" =~ "$f" ]]; then
       log "(required) '$f' has been modified. Great!"


### PR DESCRIPTION
## Summary

We hit this CI error while attempting a release: https://github.com/lacework/terraform-gcp-agentless-scanning/actions/runs/17411138516/job/49428594242

The important part reads: 
```
'git whatchanged' is nominated for removal.
If you still use this command, please add an extra
option, '--i-still-use-this', on the command line
```

.... I am adding this option so the verification doesn't fail and we can proceed with our release.

## How did you test this change?
Proof is in the pudding. A green "verify release" CI run means the change worked.

## Issue
N/A