### PR TITLE
Fix conditions for specifying the organization_id variable

### DIFF
--- a/checks.tf
+++ b/checks.tf
@@ -3,7 +3,7 @@ check "non_empty_organization_id" {
   // in a folder. In this case, google_project.selected[0].org_id will be empty whereas google_project.selected[0].folder_id
   // will be non-empty. We'd need to ask the user to provide the organization_id in such cases.
   assert {
-    condition     = local.organization_id != "" && local.integration_type == "ORGANIZATION"
+    condition     = var.organization_id != "" || var.integration_type == "PROJECT"
     error_message = "No `organization_id` is provided and we failed to derive one. Please provide `organization_id`."
   }
 }


### PR DESCRIPTION
## Summary

The last changeset removed the requirement for specifying an `organization_id` in `PROJECT` level integrations.

Unfortunately, my changes to the Terraform check for this variable had an error. As a result we are firing the "you must include an org ID" for all integrations still.

This PR rectifies that problem.

## How did you test this change?
I created a local terraform integration with this change. I verified that:
1. When integration type is `PROJECT` and no organization id is specified, we do not get the warning.
2. When integration type is `ORGANIZATION` and no organization id is specified, we do get the warning.
3. 2. When integration type is `ORGANIZATION` and an organization id is specified, we do not get the warning.
